### PR TITLE
feat: replace liveness probe with httpGet when instance manager enabled

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -427,6 +427,41 @@ jobs:
             sleep 5
           done
 
+      - name: Verify httpGet liveness probe is configured
+        run: |
+          echo "Checking liveness probe configuration..."
+          PROBE_TYPE=$(kubectl get statefulset rfr-test-im -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.httpGet.path}')
+          echo "Liveness probe path: $PROBE_TYPE"
+          if [[ "$PROBE_TYPE" == "/healthz" ]]; then
+            echo "✓ HTTP liveness probe is configured with /healthz path"
+          else
+            echo "✗ Expected httpGet probe with /healthz path"
+            kubectl get statefulset rfr-test-im -o yaml | grep -A 10 livenessProbe
+            exit 1
+          fi
+
+          PROBE_PORT=$(kubectl get statefulset rfr-test-im -o jsonpath='{.spec.template.spec.containers[0].livenessProbe.httpGet.port}')
+          echo "Liveness probe port: $PROBE_PORT"
+          if [[ "$PROBE_PORT" == "8080" ]]; then
+            echo "✓ HTTP liveness probe is configured on port 8080"
+          else
+            echo "✗ Expected probe on port 8080, got $PROBE_PORT"
+            exit 1
+          fi
+
+      - name: Verify health port is exposed
+        run: |
+          echo "Checking container ports..."
+          HEALTH_PORT=$(kubectl get statefulset rfr-test-im -o jsonpath='{.spec.template.spec.containers[0].ports[?(@.name=="health")].containerPort}')
+          echo "Health port: $HEALTH_PORT"
+          if [[ "$HEALTH_PORT" == "8080" ]]; then
+            echo "✓ Health port 8080 is exposed"
+          else
+            echo "✗ Expected health port 8080"
+            kubectl get statefulset rfr-test-im -o jsonpath='{.spec.template.spec.containers[0].ports}'
+            exit 1
+          fi
+
       - name: Verify instance manager is PID 1
         run: |
           echo "Checking process tree..."


### PR DESCRIPTION
## Summary

Replaces the process-spawning liveness probe with an HTTP probe to `/healthz:8080` when instance manager is enabled.

Fixes #7

## Changes

| Condition | Liveness Probe |
|-----------|----------------|
| `instanceManagerImage` set | `httpGet /healthz:8080` |
| `instanceManagerImage` not set | `exec redis-cli ping` (legacy) |

## Before (exec probe)
```yaml
livenessProbe:
  exec:
    command: ["sh", "-c", "redis-cli ... ping | grep PONG"]
```

**Problems:**
- Spawns new process every 15 seconds
- redis-cli startup adds ~50ms latency
- Fails under memory pressure

## After (httpGet probe)
```yaml
livenessProbe:
  httpGet:
    path: /healthz
    port: 8080
```

**Benefits:**
- No process spawning
- ~1-5ms latency
- Works under memory pressure

## Backwards Compatibility

- Only applies when `instanceManagerImage` is set
- Legacy exec probe used when instance manager not enabled
- No breaking changes for existing deployments

## Test Coverage

- Unit tests for HTTP probe when instance manager enabled
- Unit tests for exec probe when instance manager disabled
- E2E tests verify httpGet probe configuration
- E2E tests verify health port is exposed

## Test Plan

- [ ] Unit tests pass
- [ ] E2E tests pass
- [ ] httpGet probe configured when instance manager enabled
- [ ] exec probe used when instance manager disabled
- [ ] Health port 8080 exposed in container spec
