### PR TITLE
feat: replace readiness probe with httpGet when instance manager enabled

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -449,6 +449,28 @@ jobs:
             exit 1
           fi
 
+      - name: Verify httpGet readiness probe is configured
+        run: |
+          echo "Checking readiness probe configuration..."
+          PROBE_TYPE=$(kubectl get statefulset rfr-test-im -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.path}')
+          echo "Readiness probe path: $PROBE_TYPE"
+          if [[ "$PROBE_TYPE" == "/readyz" ]]; then
+            echo "✓ HTTP readiness probe is configured with /readyz path"
+          else
+            echo "✗ Expected httpGet probe with /readyz path"
+            kubectl get statefulset rfr-test-im -o yaml | grep -A 10 readinessProbe
+            exit 1
+          fi
+
+          PROBE_PORT=$(kubectl get statefulset rfr-test-im -o jsonpath='{.spec.template.spec.containers[0].readinessProbe.httpGet.port}')
+          echo "Readiness probe port: $PROBE_PORT"
+          if [[ "$PROBE_PORT" == "8080" ]]; then
+            echo "✓ HTTP readiness probe is configured on port 8080"
+          else
+            echo "✗ Expected probe on port 8080, got $PROBE_PORT"
+            exit 1
+          fi
+
       - name: Verify health port is exposed
         run: |
           echo "Checking container ports..."


### PR DESCRIPTION
## Summary

Replaces the process-spawning readiness probe with an HTTP probe to `/readyz:8080` when instance manager is enabled.

Fixes #8

## Changes

| Condition | Readiness Probe |
|-----------|-----------------|
| `instanceManagerImage` set | `httpGet /readyz:8080` |
| `instanceManagerImage` not set | `exec ready.sh` (legacy) |

## Operation Comparison: ready.sh vs /readyz

| Condition | ready.sh | /readyz |
|-----------|----------|---------|
| Master role | ✅ Always ready | ✅ Always ready (unless loading) |
| `loading:1` | ❌ Not checked | ✅ NOT ready |
| `master_sync_in_progress:1` | ✅ NOT ready | ✅ NOT ready |
| `master_host:127.0.0.1` | ✅ NOT ready | ✅ NOT ready |
| `master_link_status:down` | ❌ Not checked | ✅ NOT ready |

The `/readyz` endpoint covers all ready.sh checks plus additional safety checks.

## Before (exec probe)
```yaml
readinessProbe:
  exec:
    command: ["/bin/sh", "/redis-readiness/ready.sh"]
```

**Problems:**
- Spawns new process every 10 seconds
- Script startup adds latency
- Fails under memory pressure

## After (httpGet probe)
```yaml
readinessProbe:
  httpGet:
    path: /readyz
    port: 8080
```

**Benefits:**
- No process spawning
- ~1-5ms latency
- Works under memory pressure
- Persistent Redis connection with cached status

## Backwards Compatibility

- Only applies when `instanceManagerImage` is set
- Legacy exec probe used when instance manager not enabled
- No breaking changes for existing deployments

## Test Plan

- [x] Unit tests for HTTP probe when instance manager enabled
- [x] Unit tests for exec probe when instance manager disabled
- [x] Unit test for no-master-configured check
- [x] E2E tests verify httpGet readiness probe configuration