### PR TITLE
feat: v4.0.0 - make instance manager required, remove legacy probes

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -56,6 +56,7 @@ jobs:
             redis:
               replicas: 3
               imagePullPolicy: IfNotPresent
+              instanceManagerImage: ghcr.io/buildio/redis-operator:test
               customLivenessProbe:
                 exec:
                   command:
@@ -397,6 +398,7 @@ jobs:
             redis:
               replicas: 2
               imagePullPolicy: IfNotPresent
+              instanceManagerImage: ghcr.io/buildio/redis-operator:test
               resources:
                 requests:
                   cpu: 100m

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,8 @@ name: Release
 on:
   push:
     tags:
-      - 'v*'
+      # Tags without leading 'v' (e.g., 4.0.0, not v4.0.0)
+      - '[0-9]*'
 
 env:
   REGISTRY: ghcr.io
@@ -110,14 +111,14 @@ jobs:
 
       - name: Update Chart version and image
         run: |
-          # Strip leading 'v' from git tag (v4.0.0 -> 4.0.0)
-          VERSION="${GITHUB_REF_NAME#v}"
+          # Git tag is the version directly (4.0.0, no 'v' prefix)
+          VERSION="${GITHUB_REF_NAME}"
 
-          # Update Chart.yaml - both version and appVersion use same value (no 'v')
+          # Update Chart.yaml - version, appVersion all match tag
           sed -i "s/^version:.*/version: $VERSION/" charts/redisoperator/Chart.yaml
           sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" charts/redisoperator/Chart.yaml
 
-          # Update values.yaml with new image (tag matches version, no 'v')
+          # Update values.yaml with new image
           sed -i "s|repository:.*|repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}|" charts/redisoperator/values.yaml
           sed -i "s/tag:.*/tag: \"$VERSION\"/" charts/redisoperator/values.yaml
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,10 +40,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Image tags include leading 'v' to match git tags (v4.0.0)
+          # This keeps versioning consistent: git tag, image tag, and chart appVersion all use v4.0.0
           tags: |
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
+            type=semver,pattern=v{{version}}
+            type=semver,pattern=v{{major}}.{{minor}}
+            type=semver,pattern=v{{major}}
             type=sha
 
       - name: Build and push Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,12 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          # Image tags include leading 'v' to match git tags (v4.0.0)
-          # This keeps versioning consistent: git tag, image tag, and chart appVersion all use v4.0.0
+          # Image tags WITHOUT leading 'v' (git tag v4.0.0 -> image tag 4.0.0)
+          # Chart version and image tag are the same (4.0.0)
           tags: |
-            type=semver,pattern=v{{version}}
-            type=semver,pattern=v{{major}}.{{minor}}
-            type=semver,pattern=v{{major}}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
             type=sha
 
       - name: Build and push Docker image
@@ -110,14 +110,16 @@ jobs:
 
       - name: Update Chart version and image
         run: |
-          # Update Chart.yaml version to match tag
+          # Strip leading 'v' from git tag (v4.0.0 -> 4.0.0)
           VERSION="${GITHUB_REF_NAME#v}"
-          sed -i "s/^version:.*/version: $VERSION/" charts/redisoperator/Chart.yaml
-          sed -i "s/^appVersion:.*/appVersion: \"$GITHUB_REF_NAME\"/" charts/redisoperator/Chart.yaml
 
-          # Update values.yaml with new image
+          # Update Chart.yaml - both version and appVersion use same value (no 'v')
+          sed -i "s/^version:.*/version: $VERSION/" charts/redisoperator/Chart.yaml
+          sed -i "s/^appVersion:.*/appVersion: \"$VERSION\"/" charts/redisoperator/Chart.yaml
+
+          # Update values.yaml with new image (tag matches version, no 'v')
           sed -i "s|repository:.*|repository: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}|" charts/redisoperator/values.yaml
-          sed -i "s/tag:.*/tag: $GITHUB_REF_NAME/" charts/redisoperator/values.yaml
+          sed -i "s/tag:.*/tag: \"$VERSION\"/" charts/redisoperator/values.yaml
 
       - name: Release Helm Chart
         uses: helm/chart-releaser-action@v1.7.0

--- a/README.md
+++ b/README.md
@@ -8,12 +8,19 @@ Redis Operator creates/configures/manages redis-failovers atop Kubernetes.
 
 This is a fork of `spotahome/redis-operator` → `Saremox/redis-operator` → `buildio/redis-operator`.
 
-## What's New in v1.7.0
+## What's New in v4.0.0
 
-**Sentinel-Free Architecture** ([#9](https://github.com/buildio/redis-operator/issues/9))
+**Breaking Change: Instance Manager Required**
 
-v1.7.0 introduces operator-managed failover as an alternative to Redis Sentinel, reducing pod overhead from 5 pods (2 Redis + 3 Sentinel) to just 2 pods (Redis only).
+v4.0.0 makes the instance manager the default and only mode. Legacy exec probes are removed.
 
+**Key changes:**
+- Instance manager is always enabled (no opt-out)
+- HTTP health probes (`/healthz`, `/readyz`) are now the only probe type
+- Default `instanceManagerImage` is `ghcr.io/buildio/redis-operator:v4.0.0`
+- Chart version aligned with operator version (4.0.0)
+
+**Minimal configuration (instance manager auto-configured):**
 ```yaml
 apiVersion: databases.spotahome.com/v1
 kind: RedisFailover
@@ -22,19 +29,34 @@ metadata:
 spec:
   redis:
     replicas: 2
-    instanceManagerImage: ghcr.io/buildio/redis-operator:v1.7.0  # Recommended for faster failure detection
   sentinel:
-    enabled: false  # Operator manages failover instead of Sentinel
-    failoverTimeout: "10s"  # Optional, defaults to 10s
+    replicas: 3
 ```
 
-**Note:** Using `instanceManagerImage` with sentinel-free mode is recommended. The instance manager's HTTP health endpoints (`/healthz`, `/readyz`) provide faster and more reliable failure detection than exec probes.
+**With sentinel-free mode:**
+```yaml
+apiVersion: databases.spotahome.com/v1
+kind: RedisFailover
+metadata:
+  name: my-redis
+spec:
+  redis:
+    replicas: 2
+  sentinel:
+    enabled: false
+```
+
+## What's New in v1.7.0
+
+**Sentinel-Free Architecture** ([#9](https://github.com/buildio/redis-operator/issues/9))
+
+v1.7.0 introduced operator-managed failover as an alternative to Redis Sentinel, reducing pod overhead from 5 pods (2 Redis + 3 Sentinel) to just 2 pods (Redis only).
 
 **How it works:**
 - Operator monitors Redis pods and detects master failures
 - On failure, promotes the replica with highest replication offset (minimizes data loss)
 - Automatically reconfigures remaining replicas to follow new master
-- Master Service (`rf-rm-<name>`) endpoints update automatically via label selectors
+- Master Service (`rfrm-<name>`) endpoints update automatically via label selectors
 
 **When to use:**
 - Development/testing environments where you want fewer pods
@@ -63,28 +85,16 @@ v1.6.0 introduces an optional instance manager that runs as PID 1 in Redis conta
 - **Zombie process reaper** - Properly handles SIGCHLD for BGSAVE/BGREWRITEAOF child processes
 - **Graceful shutdown** - Timeout escalation (SIGTERM → SIGKILL) for reliable shutdown
 
-**Enable it per-RedisFailover:**
-```yaml
-apiVersion: databases.spotahome.com/v1
-kind: RedisFailover
-metadata:
-  name: my-redis
-spec:
-  redis:
-    replicas: 3
-    instanceManagerImage: ghcr.io/buildio/redis-operator:v1.7.0
-  sentinel:
-    replicas: 3
-```
+**Enabled by default in v4.0.0+** - no configuration needed.
 
 ### Roadmap
 
 | Version | Features | Notes |
 |---------|----------|-------|
-| v1.6.1 | Instance Manager opt-in | `instanceManagerImage` field |
-| v1.7.0 | Sentinel-free mode | Current release - `sentinel.enabled: false` |
-| v1.8.0 | Instance Manager default | Opt-out via `instanceManagerImage: ""` |
-| v2.0.0 | Instance Manager required | Legacy mode removed |
+| v1.6.0 | Instance Manager opt-in | `instanceManagerImage` field |
+| v1.6.1 | Disable service links | Prevents startup failures in busy namespaces |
+| v1.7.0 | Sentinel-free mode | `sentinel.enabled: false` |
+| v4.0.0 | Instance Manager required | Current release - legacy probes removed, chart/operator versions aligned |
 
 See [Issue #2](https://github.com/buildio/redis-operator/issues/2) for instance manager details and [Issue #9](https://github.com/buildio/redis-operator/issues/9) for sentinel-free architecture.
 
@@ -119,7 +129,7 @@ helm install redis-operator redis-operator/redis-operator
 ### Install with kubectl
 
 ```bash
-REDIS_OPERATOR_VERSION=v1.7.0
+REDIS_OPERATOR_VERSION=v4.0.0
 kubectl apply --server-side -f https://raw.githubusercontent.com/buildio/redis-operator/${REDIS_OPERATOR_VERSION}/manifests/databases.spotahome.com_redisfailovers.yaml
 kubectl apply -f https://raw.githubusercontent.com/buildio/redis-operator/${REDIS_OPERATOR_VERSION}/example/operator/all-redis-operator-resources.yaml
 ```
@@ -128,13 +138,13 @@ kubectl apply -f https://raw.githubusercontent.com/buildio/redis-operator/${REDI
 
 ```bash
 # Default installation with RBAC, service account, resource limits
-kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/default?ref=v1.7.0 | kubectl apply -f -
+kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/default?ref=v4.0.0 | kubectl apply -f -
 
 # Minimal installation
-kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/minimal?ref=v1.7.0 | kubectl apply -f -
+kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/minimal?ref=v4.0.0 | kubectl apply -f -
 
 # Full installation with Prometheus ServiceMonitor
-kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/full?ref=v1.7.0 | kubectl apply -f -
+kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/full?ref=v4.0.0 | kubectl apply -f -
 ```
 
 ## Updating
@@ -144,7 +154,7 @@ kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/f
 Helm only manages CRD creation on first install. To update the CRD:
 
 ```bash
-REDIS_OPERATOR_VERSION=v1.7.0
+REDIS_OPERATOR_VERSION=v4.0.0
 kubectl replace --server-side -f https://raw.githubusercontent.com/buildio/redis-operator/${REDIS_OPERATOR_VERSION}/manifests/databases.spotahome.com_redisfailovers.yaml
 ```
 
@@ -159,7 +169,7 @@ helm upgrade redis-operator redis-operator/redis-operator
 ### Create a Redis Failover
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/buildio/redis-operator/v1.7.0/example/redisfailover/basic.yaml
+kubectl apply -f https://raw.githubusercontent.com/buildio/redis-operator/v4.0.0/example/redisfailover/basic.yaml
 ```
 
 This creates the following resources:
@@ -179,13 +189,12 @@ metadata:
   name: my-redis
 spec:
   redis:
-    replicas: 3
-    instanceManagerImage: ghcr.io/buildio/redis-operator:v1.7.0
+    replicas: 2
   sentinel:
     replicas: 3
 ```
 
-When `instanceManagerImage` is set:
+The instance manager is enabled by default:
 1. An init container copies the `redis-instance` binary to a shared volume
 2. The main container runs `redis-instance run` as PID 1
 3. The instance manager performs cleanup and manages Redis as a child process
@@ -202,15 +211,14 @@ metadata:
 spec:
   redis:
     replicas: 2
-    instanceManagerImage: ghcr.io/buildio/redis-operator:v1.7.0  # Recommended
   sentinel:
     enabled: false
     failoverTimeout: "10s"  # Optional, defaults to 10s
 ```
 
-**Why use instanceManagerImage with sentinel-free mode?**
+**How failure detection works:**
 
-Without Sentinel, failure detection relies on the operator's health checks. The instance manager provides:
+The instance manager provides HTTP health endpoints (`/healthz`, `/readyz`) that enable:
 - HTTP health probes (faster than exec probes)
 - Immediate detection of Redis process crashes
 - No process spawning overhead during health checks

--- a/README.md
+++ b/README.md
@@ -15,11 +15,12 @@ This is a fork of `spotahome/redis-operator` → `Saremox/redis-operator` → `b
 v4.0.0 makes the instance manager the default and only mode. Legacy exec probes are removed.
 
 **Key changes:**
+- **Sentinel disabled by default** - operator-managed failover is now the default
 - Instance manager is always enabled (no opt-out)
 - HTTP health probes (`/healthz`, `/readyz`) are now the only probe type
-- Chart version aligned with operator version (4.0.0 / v4.0.0)
+- Chart version aligned with operator version (4.0.0)
 
-**Minimal configuration (instance manager auto-configured):**
+**Minimal configuration (operator-managed failover, no sentinel):**
 ```yaml
 apiVersion: databases.spotahome.com/v1
 kind: RedisFailover
@@ -28,11 +29,9 @@ metadata:
 spec:
   redis:
     replicas: 2
-  sentinel:
-    replicas: 3
 ```
 
-**With sentinel-free mode:**
+**With Redis Sentinel (opt-in):**
 ```yaml
 apiVersion: databases.spotahome.com/v1
 kind: RedisFailover
@@ -42,7 +41,8 @@ spec:
   redis:
     replicas: 2
   sentinel:
-    enabled: false
+    enabled: true
+    replicas: 3
 ```
 
 ## What's New in v1.7.0
@@ -106,17 +106,15 @@ Tested against Kubernetes 1.29, 1.30, 1.31, 1.32, 1.33, 1.34 and Redis 6, 7.
 
 ## Versioning
 
-**Chart version, appVersion, and Docker image tag are identical** (no leading `v`):
+**Starting with 4.0.0, we no longer use 'v' prefix anywhere:**
 
-| Git Tag | Chart Version | Image Tag | Notes |
-|---------|---------------|-----------|-------|
-| v4.0.0 | 4.0.0 | 4.0.0 | Git tag has `v`, everything else doesn't |
+| Git Tag | Chart Version | Image Tag |
+|---------|---------------|-----------|
+| 4.0.0 | 4.0.0 | 4.0.0 |
 
-**Example:** Git tag `v4.0.0` produces:
-- Helm chart version: `4.0.0`
-- Docker image: `ghcr.io/buildio/redis-operator:4.0.0`
+**Warning:** Previous releases used `v` prefix for git tags (e.g., `v1.7.0`). Starting with 4.0.0, git tags are bare version numbers (e.g., `4.0.0`).
 
-If you don't specify `image.tag`, the chart automatically uses the appVersion (e.g., `4.0.0`).
+If you don't specify `image.tag`, the chart automatically uses the appVersion.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ helm install redis-operator redis-operator/redis-operator
 ### Install with kubectl
 
 ```bash
-REDIS_OPERATOR_VERSION=v4.0.0
+REDIS_OPERATOR_VERSION=4.0.0
 kubectl apply --server-side -f https://raw.githubusercontent.com/buildio/redis-operator/${REDIS_OPERATOR_VERSION}/manifests/databases.spotahome.com_redisfailovers.yaml
 kubectl apply -f https://raw.githubusercontent.com/buildio/redis-operator/${REDIS_OPERATOR_VERSION}/example/operator/all-redis-operator-resources.yaml
 ```
@@ -151,13 +151,13 @@ kubectl apply -f https://raw.githubusercontent.com/buildio/redis-operator/${REDI
 
 ```bash
 # Default installation with RBAC, service account, resource limits
-kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/default?ref=v4.0.0 | kubectl apply -f -
+kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/default?ref=4.0.0 | kubectl apply -f -
 
 # Minimal installation
-kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/minimal?ref=v4.0.0 | kubectl apply -f -
+kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/minimal?ref=4.0.0 | kubectl apply -f -
 
 # Full installation with Prometheus ServiceMonitor
-kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/full?ref=v4.0.0 | kubectl apply -f -
+kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/full?ref=4.0.0 | kubectl apply -f -
 ```
 
 ## Updating
@@ -167,7 +167,7 @@ kustomize build github.com/buildio/redis-operator/manifests/kustomize/overlays/f
 Helm only manages CRD creation on first install. To update the CRD:
 
 ```bash
-REDIS_OPERATOR_VERSION=v4.0.0
+REDIS_OPERATOR_VERSION=4.0.0
 kubectl replace --server-side -f https://raw.githubusercontent.com/buildio/redis-operator/${REDIS_OPERATOR_VERSION}/manifests/databases.spotahome.com_redisfailovers.yaml
 ```
 
@@ -182,7 +182,7 @@ helm upgrade redis-operator redis-operator/redis-operator
 ### Create a Redis Failover
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/buildio/redis-operator/v4.0.0/example/redisfailover/basic.yaml
+kubectl apply -f https://raw.githubusercontent.com/buildio/redis-operator/4.0.0/example/redisfailover/basic.yaml
 ```
 
 This creates the following resources:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ v4.0.0 makes the instance manager the default and only mode. Legacy exec probes 
 **Key changes:**
 - Instance manager is always enabled (no opt-out)
 - HTTP health probes (`/healthz`, `/readyz`) are now the only probe type
-- Default `instanceManagerImage` is `ghcr.io/buildio/redis-operator:v4.0.0`
+- Default `instanceManagerImage` is `ghcr.io/buildio/redis-operator:v1.7.0`
 - Chart version aligned with operator version (4.0.0)
 
 **Minimal configuration (instance manager auto-configured):**

--- a/README.md
+++ b/README.md
@@ -106,20 +106,17 @@ Tested against Kubernetes 1.29, 1.30, 1.31, 1.32, 1.33, 1.34 and Redis 6, 7.
 
 ## Versioning
 
-**Chart and image versions are aligned.** Starting with v4.0.0:
+**Chart version, appVersion, and Docker image tag are identical** (no leading `v`):
 
-| Chart Version | Image Tag | Git Tag | Notes |
-|---------------|-----------|---------|-------|
-| 4.0.0 | v4.0.0 | v4.0.0 | All use leading `v` for image/git |
+| Git Tag | Chart Version | Image Tag | Notes |
+|---------|---------------|-----------|-------|
+| v4.0.0 | 4.0.0 | 4.0.0 | Git tag has `v`, everything else doesn't |
 
-**Important:**
-- **Helm chart version**: `4.0.0` (no leading `v`, per Helm convention)
-- **Docker image tag**: `v4.0.0` (includes leading `v`)
-- **Git tag**: `v4.0.0` (includes leading `v`)
+**Example:** Git tag `v4.0.0` produces:
+- Helm chart version: `4.0.0`
+- Docker image: `ghcr.io/buildio/redis-operator:4.0.0`
 
-**Note:** Historical releases (v1.7.0 and earlier) used image tags without leading `v` (e.g., `1.7.0`).
-
-If you don't specify `image.tag`, the chart automatically uses the correct image version matching the chart's appVersion.
+If you don't specify `image.tag`, the chart automatically uses the appVersion (e.g., `4.0.0`).
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ v4.0.0 makes the instance manager the default and only mode. Legacy exec probes 
 **Key changes:**
 - Instance manager is always enabled (no opt-out)
 - HTTP health probes (`/healthz`, `/readyz`) are now the only probe type
-- Default `instanceManagerImage` is `ghcr.io/buildio/redis-operator:v1.7.0`
-- Chart version aligned with operator version (4.0.0)
+- Chart version aligned with operator version (4.0.0 / v4.0.0)
 
 **Minimal configuration (instance manager auto-configured):**
 ```yaml
@@ -105,20 +104,39 @@ See [Issue #2](https://github.com/buildio/redis-operator/issues/2) for instance 
 
 Tested against Kubernetes 1.29, 1.30, 1.31, 1.32, 1.33, 1.34 and Redis 6, 7.
 
+## Versioning
+
+**Chart and image versions are aligned.** Starting with v4.0.0:
+
+| Chart Version | Image Tag | Git Tag | Notes |
+|---------------|-----------|---------|-------|
+| 4.0.0 | v4.0.0 | v4.0.0 | All use leading `v` for image/git |
+
+**Important:**
+- **Helm chart version**: `4.0.0` (no leading `v`, per Helm convention)
+- **Docker image tag**: `v4.0.0` (includes leading `v`)
+- **Git tag**: `v4.0.0` (includes leading `v`)
+
+**Note:** Historical releases (v1.7.0 and earlier) used image tags without leading `v` (e.g., `1.7.0`).
+
+If you don't specify `image.tag`, the chart automatically uses the correct image version matching the chart's appVersion.
+
 ## Quick Start
 
-### Install from GitHub Container Registry
+### Install from GitHub Container Registry (Recommended)
 
 ```bash
 # Install CRD
 kubectl apply --server-side -f https://raw.githubusercontent.com/buildio/redis-operator/main/manifests/databases.spotahome.com_redisfailovers.yaml
 
-# Install operator
+# Install operator (uses default image version matching chart)
 helm upgrade --install redis-operator oci://ghcr.io/buildio/redis-operator/charts/redisoperator \
   --namespace redis-operator --create-namespace
 ```
 
-### Install with Helm
+No additional parameters required - the chart defaults to the correct image version.
+
+### Install with Helm Repository
 
 ```bash
 helm repo add redis-operator https://buildio.github.io/redis-operator

--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -19,8 +19,9 @@ const (
 	// DefaultInstanceManagerImage is the default image used for the instance manager.
 	// This image contains the redis-instance binary that runs as PID 1.
 	// Users can override this per-RedisFailover via spec.redis.instanceManagerImage.
-	// NOTE: This must reference an existing released version with the redis-instance binary.
-	DefaultInstanceManagerImage = "ghcr.io/buildio/redis-operator:v1.7.0"
+	// NOTE: Historical releases (pre-v4.0.0) used tags without leading 'v' (e.g., 1.7.0).
+	// Starting with v4.0.0, tags include leading 'v' (e.g., v4.0.0).
+	DefaultInstanceManagerImage = "ghcr.io/buildio/redis-operator:1.7.0"
 )
 
 var (

--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -19,12 +19,12 @@ const (
 	// DefaultInstanceManagerImage is the default image used for the instance manager.
 	// This image contains the redis-instance binary that runs as PID 1.
 	// Users can override this per-RedisFailover via spec.redis.instanceManagerImage.
-	DefaultInstanceManagerImage = "ghcr.io/buildio/redis-operator:1.7.0"
+	DefaultInstanceManagerImage = "ghcr.io/buildio/redis-operator:4.0.0"
 )
 
 var (
 	// DefaultSentinelEnabled is the default value for sentinel.enabled
-	// Starting with v4.0.0, sentinel is DISABLED by default (operator-managed failover)
+	// Starting with 4.0.0, sentinel is DISABLED by default (operator-managed failover)
 	// Set sentinel.enabled: true to use Redis Sentinel for failover
 	DefaultSentinelEnabled = false
 	// DefaultFailoverTimeout is the default timeout for operator-managed failover

--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -19,14 +19,14 @@ const (
 	// DefaultInstanceManagerImage is the default image used for the instance manager.
 	// This image contains the redis-instance binary that runs as PID 1.
 	// Users can override this per-RedisFailover via spec.redis.instanceManagerImage.
-	// NOTE: Historical releases (pre-v4.0.0) used tags without leading 'v' (e.g., 1.7.0).
-	// Starting with v4.0.0, tags include leading 'v' (e.g., v4.0.0).
 	DefaultInstanceManagerImage = "ghcr.io/buildio/redis-operator:1.7.0"
 )
 
 var (
 	// DefaultSentinelEnabled is the default value for sentinel.enabled
-	DefaultSentinelEnabled = true
+	// Starting with v4.0.0, sentinel is DISABLED by default (operator-managed failover)
+	// Set sentinel.enabled: true to use Redis Sentinel for failover
+	DefaultSentinelEnabled = false
 	// DefaultFailoverTimeout is the default timeout for operator-managed failover
 	DefaultFailoverTimeout = metav1.Duration{Duration: 10 * time.Second}
 )

--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -15,6 +15,11 @@ const (
 	defaultRedisPort             = 6379
 	HealthyState                 = "Healthy"
 	NotHealthyState              = "NotHealthy"
+
+	// DefaultInstanceManagerImage is the default image used for the instance manager.
+	// This image contains the redis-instance binary that runs as PID 1.
+	// Users can override this per-RedisFailover via spec.redis.instanceManagerImage.
+	DefaultInstanceManagerImage = "ghcr.io/buildio/redis-operator:v4.0.0"
 )
 
 var (

--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -19,7 +19,8 @@ const (
 	// DefaultInstanceManagerImage is the default image used for the instance manager.
 	// This image contains the redis-instance binary that runs as PID 1.
 	// Users can override this per-RedisFailover via spec.redis.instanceManagerImage.
-	DefaultInstanceManagerImage = "ghcr.io/buildio/redis-operator:v4.0.0"
+	// NOTE: This must reference an existing released version with the redis-instance binary.
+	DefaultInstanceManagerImage = "ghcr.io/buildio/redis-operator:v1.7.0"
 )
 
 var (

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -1,8 +1,10 @@
-appVersion: 4.0.0
 apiVersion: v1
-description: A Helm chart for the Saremox Redis Operator
 name: redis-operator
 version: 4.0.0
+# appVersion is the Docker image tag. Must include leading "v".
+# Chart version 4.0.0 -> image tag v4.0.0
+appVersion: v4.0.0
+description: A Helm chart for the Redis Operator
 home: https://github.com/saremox/redis-operator
 keywords:
   - "golang"

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -1,8 +1,8 @@
-appVersion: 1.7.0
+appVersion: 4.0.0
 apiVersion: v1
 description: A Helm chart for the Saremox Redis Operator
 name: redis-operator
-version: 3.7.0
+version: 4.0.0
 home: https://github.com/saremox/redis-operator
 keywords:
   - "golang"

--- a/charts/redisoperator/Chart.yaml
+++ b/charts/redisoperator/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
 name: redis-operator
 version: 4.0.0
-# appVersion is the Docker image tag. Must include leading "v".
-# Chart version 4.0.0 -> image tag v4.0.0
-appVersion: v4.0.0
+# appVersion matches the Docker image tag (no leading "v")
+# Chart version, appVersion, and image tag are all the same: 4.0.0
+appVersion: "4.0.0"
 description: A Helm chart for the Redis Operator
 home: https://github.com/saremox/redis-operator
 keywords:

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -6,8 +6,8 @@
 image:
   repository: ghcr.io/buildio/redis-operator
   pullPolicy: IfNotPresent
-  # Image tag. If not specified, defaults to Chart appVersion (e.g., "v4.0.0").
-  # Note: Tags always include the leading "v" (v4.0.0, not 4.0.0).
+  # Image tag. If not specified, defaults to Chart appVersion (e.g., "4.0.0").
+  # Note: Starting with 4.0.0, tags do NOT have a leading "v" (4.0.0, not v4.0.0).
   tag: ""
   cli_args: ""
 

--- a/charts/redisoperator/values.yaml
+++ b/charts/redisoperator/values.yaml
@@ -6,7 +6,9 @@
 image:
   repository: ghcr.io/buildio/redis-operator
   pullPolicy: IfNotPresent
-  tag: v1.5.0
+  # Image tag. If not specified, defaults to Chart appVersion (e.g., "v4.0.0").
+  # Note: Tags always include the leading "v" (v4.0.0, not 4.0.0).
+  tag: ""
   cli_args: ""
 
 imageCredentials:

--- a/cmd/instance/run/cmd.go
+++ b/cmd/instance/run/cmd.go
@@ -108,7 +108,8 @@ func runInstance(cmd *cobra.Command, args []string) error {
 	}
 
 	// Step 3: Start health server (provides /healthz, /readyz, /status)
-	healthServer = NewHealthServer(healthPort, redisPort)
+	redisPassword := os.Getenv("REDIS_PASSWORD")
+	healthServer = NewHealthServer(healthPort, redisPort, redisPassword)
 	healthServer.SetCleanupDone(cleanupErr == nil)
 	if err := healthServer.Start(ctx); err != nil {
 		fmt.Printf("redis-instance: warning: failed to start health server: %v\n", err)

--- a/cmd/instance/run/health_test.go
+++ b/cmd/instance/run/health_test.go
@@ -83,7 +83,7 @@ loading_loaded_bytes:500000
 }
 
 func TestHealthServerHealthzHealthy(t *testing.T) {
-	h := NewHealthServer(8080, "6379")
+	h := NewHealthServer(8080, "6379", "")
 	h.startTime = time.Now().Add(-60 * time.Second) // 60 seconds ago
 	h.SetRedisPID(1234)
 	h.redisHealthy.Store(true)
@@ -105,7 +105,7 @@ func TestHealthServerHealthzHealthy(t *testing.T) {
 }
 
 func TestHealthServerHealthzUnhealthy(t *testing.T) {
-	h := NewHealthServer(8080, "6379")
+	h := NewHealthServer(8080, "6379", "")
 	h.redisHealthy.Store(false)
 
 	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
@@ -124,7 +124,7 @@ func TestHealthServerHealthzUnhealthy(t *testing.T) {
 }
 
 func TestHealthServerReadyzReady(t *testing.T) {
-	h := NewHealthServer(8080, "6379")
+	h := NewHealthServer(8080, "6379", "")
 	h.redisReady.Store(true)
 	h.redisHealthy.Store(true)
 
@@ -154,7 +154,7 @@ func TestHealthServerReadyzReady(t *testing.T) {
 }
 
 func TestHealthServerReadyzNotReadyLoading(t *testing.T) {
-	h := NewHealthServer(8080, "6379")
+	h := NewHealthServer(8080, "6379", "")
 	h.redisReady.Store(false)
 	h.redisHealthy.Store(true)
 
@@ -182,7 +182,7 @@ func TestHealthServerReadyzNotReadyLoading(t *testing.T) {
 }
 
 func TestHealthServerReadyzNotReadySyncing(t *testing.T) {
-	h := NewHealthServer(8080, "6379")
+	h := NewHealthServer(8080, "6379", "")
 	h.redisReady.Store(false)
 	h.redisHealthy.Store(true)
 
@@ -212,7 +212,7 @@ func TestHealthServerReadyzNotReadySyncing(t *testing.T) {
 }
 
 func TestHealthServerReadyzNotReadyMasterLinkDown(t *testing.T) {
-	h := NewHealthServer(8080, "6379")
+	h := NewHealthServer(8080, "6379", "")
 	h.redisReady.Store(false)
 	h.redisHealthy.Store(true)
 
@@ -240,7 +240,7 @@ func TestHealthServerReadyzNotReadyMasterLinkDown(t *testing.T) {
 }
 
 func TestHealthServerReadyzNotReadyNoMasterConfigured(t *testing.T) {
-	h := NewHealthServer(8080, "6379")
+	h := NewHealthServer(8080, "6379", "")
 	h.redisReady.Store(false)
 	h.redisHealthy.Store(true)
 
@@ -269,7 +269,7 @@ func TestHealthServerReadyzNotReadyNoMasterConfigured(t *testing.T) {
 }
 
 func TestHealthServerStatus(t *testing.T) {
-	h := NewHealthServer(8080, "6379")
+	h := NewHealthServer(8080, "6379", "")
 	h.startTime = time.Now().Add(-120 * time.Second)
 	h.SetRedisPID(5678)
 	h.SetCleanupDone(true)
@@ -313,14 +313,14 @@ func TestHealthServerStatus(t *testing.T) {
 	assert.Equal(t, int64(99999), resp.Replication.MasterReplOffset)
 
 	// Instance manager status
-	assert.Equal(t, "v1.7.0", resp.InstanceManager.Version)
+	assert.Equal(t, "4.0.0", resp.InstanceManager.Version)
 	assert.GreaterOrEqual(t, resp.InstanceManager.UptimeSeconds, int64(120))
 	assert.True(t, resp.InstanceManager.StartupCleanupDone)
 	assert.Equal(t, 8080, resp.InstanceManager.HealthPort)
 }
 
 func TestHealthServerMethodNotAllowed(t *testing.T) {
-	h := NewHealthServer(8080, "6379")
+	h := NewHealthServer(8080, "6379", "")
 
 	endpoints := []string{"/healthz", "/readyz", "/status"}
 	methods := []string{http.MethodPost, http.MethodPut, http.MethodDelete}
@@ -369,7 +369,7 @@ func TestIndexByte(t *testing.T) {
 }
 
 func TestHealthServerStartStop(t *testing.T) {
-	h := NewHealthServer(0, "6379") // Port 0 = random available port
+	h := NewHealthServer(0, "6379", "") // Port 0 = random available port
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/example/operator/all-redis-operator-resources.yaml
+++ b/example/operator/all-redis-operator-resources.yaml
@@ -19,7 +19,7 @@ spec:
       serviceAccountName: redisoperator
       enableServiceLinks: false
       containers:
-        - image: ghcr.io/buildio/redis-operator:v1.6.1
+        - image: ghcr.io/buildio/redis-operator:4.0.0
           imagePullPolicy: IfNotPresent
           name: app
           securityContext:

--- a/manifests/kustomize/base/deployment.yaml
+++ b/manifests/kustomize/base/deployment.yaml
@@ -11,7 +11,7 @@ spec:
       enableServiceLinks: false
       containers:
         - name: redis-operator
-          image: ghcr.io/buildio/redis-operator:v1.6.1
+          image: ghcr.io/buildio/redis-operator:4.0.0
           imagePullPolicy: IfNotPresent
           securityContext:
             readOnlyRootFilesystem: true

--- a/operator/redisfailover/ensurer_test.go
+++ b/operator/redisfailover/ensurer_test.go
@@ -28,6 +28,9 @@ func generateConfig() rfOperator.Config {
 }
 
 func generateRF(enableExporter bool, bootstrapping bool) *redisfailoverv1.RedisFailover {
+	// Explicitly enable sentinel for tests that expect sentinel behavior
+	// (sentinel is disabled by default in v4.0.0+)
+	sentinelEnabled := true
 	return &redisfailoverv1.RedisFailover{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -41,6 +44,7 @@ func generateRF(enableExporter bool, bootstrapping bool) *redisfailoverv1.RedisF
 				},
 			},
 			Sentinel: redisfailoverv1.SentinelSettings{
+				Enabled:  &sentinelEnabled,
 				Replicas: int32(3),
 			},
 			BootstrapNode: generateRFBootstrappingNode(bootstrapping),

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -470,6 +470,24 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 				Protocol:      corev1.ProtocolTCP,
 			},
 		)
+
+		// Add REDIS_PASSWORD env var for instance manager health checks
+		if rf.Spec.Auth.SecretPath != "" {
+			ss.Spec.Template.Spec.Containers[0].Env = append(
+				ss.Spec.Template.Spec.Containers[0].Env,
+				corev1.EnvVar{
+					Name: "REDIS_PASSWORD",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: rf.Spec.Auth.SecretPath,
+							},
+							Key: "password",
+						},
+					},
+				},
+			)
+		}
 	}
 
 	if rf.Spec.Redis.CustomLivenessProbe != nil {

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -474,8 +474,8 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 
 	if rf.Spec.Redis.CustomLivenessProbe != nil {
 		ss.Spec.Template.Spec.Containers[0].LivenessProbe = rf.Spec.Redis.CustomLivenessProbe
-	} else if instanceManagerEnabled(rf) {
-		// Use HTTP probe when instance manager is enabled (CNPG model)
+	} else {
+		// HTTP probe via instance manager (CNPG model)
 		// This avoids process spawning and works better under memory pressure
 		ss.Spec.Template.Spec.Containers[0].LivenessProbe = &corev1.Probe{
 			InitialDelaySeconds: graceTime,
@@ -489,29 +489,12 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 				},
 			},
 		}
-	} else {
-		// Legacy exec probe for backwards compatibility
-		ss.Spec.Template.Spec.Containers[0].LivenessProbe = &corev1.Probe{
-			InitialDelaySeconds: graceTime,
-			TimeoutSeconds:      5,
-			FailureThreshold:    6,
-			PeriodSeconds:       15,
-			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{
-						"sh",
-						"-c",
-						fmt.Sprintf("redis-cli -h $(hostname) -p %[1]v --user pinger --pass pingpass --no-auth-warning ping | grep PONG", rf.Spec.Redis.Port),
-					},
-				},
-			},
-		}
 	}
 
 	if rf.Spec.Redis.CustomReadinessProbe != nil {
 		ss.Spec.Template.Spec.Containers[0].ReadinessProbe = rf.Spec.Redis.CustomReadinessProbe
-	} else if instanceManagerEnabled(rf) {
-		// Use HTTP probe when instance manager is enabled (CNPG model)
+	} else {
+		// HTTP probe via instance manager (CNPG model)
 		// The /readyz endpoint checks: not loading, not syncing, master link up
 		ss.Spec.Template.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
 			InitialDelaySeconds: graceTime,
@@ -522,17 +505,6 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 				HTTPGet: &corev1.HTTPGetAction{
 					Path: instanceManagerReadyzPath,
 					Port: intstr.FromInt32(instanceManagerHealthPort),
-				},
-			},
-		}
-	} else {
-		// Legacy exec probe for backwards compatibility
-		ss.Spec.Template.Spec.Containers[0].ReadinessProbe = &corev1.Probe{
-			InitialDelaySeconds: graceTime,
-			TimeoutSeconds:      5,
-			ProbeHandler: corev1.ProbeHandler{
-				Exec: &corev1.ExecAction{
-					Command: []string{"/bin/sh", "/redis-readiness/ready.sh"},
 				},
 			},
 		}
@@ -1162,26 +1134,32 @@ func getRedisCommand(rf *redisfailoverv1.RedisFailover) []string {
 	if len(rf.Spec.Redis.Command) > 0 {
 		return rf.Spec.Redis.Command
 	}
-	// If instance manager is enabled, use it as PID 1 (CNPG model)
-	if rf.Spec.Redis.InstanceManagerImage != "" {
-		return []string{
-			fmt.Sprintf("%s/%s", instanceManagerMountPath, instanceManagerBinaryName),
-			"run",
-			"--redis-conf", fmt.Sprintf("/redis/%s", redisConfigFileName),
-		}
-	}
+	// Instance manager runs as PID 1 (CNPG model)
+	// This is required in v4.0.0+ - legacy mode is removed
 	return []string{
-		"redis-server",
-		fmt.Sprintf("/redis/%s", redisConfigFileName),
+		fmt.Sprintf("%s/%s", instanceManagerMountPath, instanceManagerBinaryName),
+		"run",
+		"--redis-conf", fmt.Sprintf("/redis/%s", redisConfigFileName),
 	}
 }
 
-// instanceManagerEnabled returns true if the instance manager is configured.
+// instanceManagerEnabled returns true if the instance manager should be used.
+// Since v4.0.0, instance manager is always enabled - legacy exec probes are removed.
 // The instance manager follows the CloudNativePG model where it runs as PID 1
 // and manages the Redis process as a child.
 // See: https://cloudnative-pg.io/documentation/current/instance_manager/
 func instanceManagerEnabled(rf *redisfailoverv1.RedisFailover) bool {
-	return rf.Spec.Redis.InstanceManagerImage != ""
+	// Always enabled in v4.0.0+. Legacy exec probes are removed.
+	return true
+}
+
+// getInstanceManagerImage returns the instance manager image to use.
+// If not specified in the CRD, uses the default operator image.
+func getInstanceManagerImage(rf *redisfailoverv1.RedisFailover) string {
+	if rf.Spec.Redis.InstanceManagerImage != "" {
+		return rf.Spec.Redis.InstanceManagerImage
+	}
+	return redisfailoverv1.DefaultInstanceManagerImage
 }
 
 // createInstanceManagerInitContainer creates an init container that copies the
@@ -1189,7 +1167,7 @@ func instanceManagerEnabled(rf *redisfailoverv1.RedisFailover) bool {
 func createInstanceManagerInitContainer(rf *redisfailoverv1.RedisFailover) corev1.Container {
 	return corev1.Container{
 		Name:            "instance-manager-init",
-		Image:           rf.Spec.Redis.InstanceManagerImage,
+		Image:           getInstanceManagerImage(rf),
 		ImagePullPolicy: pullPolicy(rf.Spec.Redis.ImagePullPolicy),
 		Command: []string{
 			"cp",

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -471,23 +471,8 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 			},
 		)
 
-		// Add REDIS_PASSWORD env var for instance manager health checks
-		if rf.Spec.Auth.SecretPath != "" {
-			ss.Spec.Template.Spec.Containers[0].Env = append(
-				ss.Spec.Template.Spec.Containers[0].Env,
-				corev1.EnvVar{
-					Name: "REDIS_PASSWORD",
-					ValueFrom: &corev1.EnvVarSource{
-						SecretKeyRef: &corev1.SecretKeySelector{
-							LocalObjectReference: corev1.LocalObjectReference{
-								Name: rf.Spec.Auth.SecretPath,
-							},
-							Key: "password",
-						},
-					},
-				},
-			)
-		}
+		// Note: REDIS_PASSWORD env var is added by getRedisEnv() when auth is configured.
+		// The instance manager health server reads this env var to authenticate to Redis.
 	}
 
 	if rf.Spec.Redis.CustomLivenessProbe != nil {

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -2572,7 +2572,7 @@ func TestRedisDefaultInstanceManagerImage(t *testing.T) {
 	for _, c := range initContainers {
 		if c.Name == "instance-manager-init" {
 			instanceManagerFound = true
-			assert.Equal("ghcr.io/buildio/redis-operator:v4.0.0", c.Image)
+			assert.Equal("ghcr.io/buildio/redis-operator:v1.7.0", c.Image)
 		}
 	}
 	assert.True(instanceManagerFound, "Expected instance-manager-init container with default image")

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -2568,11 +2568,12 @@ func TestRedisDefaultInstanceManagerImage(t *testing.T) {
 	assert.NoError(err)
 
 	// Verify instance manager init container uses default image
+	// Note: Historical releases use tags without leading 'v' (1.7.0)
 	var instanceManagerFound bool
 	for _, c := range initContainers {
 		if c.Name == "instance-manager-init" {
 			instanceManagerFound = true
-			assert.Equal("ghcr.io/buildio/redis-operator:v1.7.0", c.Image)
+			assert.Equal("ghcr.io/buildio/redis-operator:1.7.0", c.Image)
 		}
 	}
 	assert.True(instanceManagerFound, "Expected instance-manager-init container with default image")

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -55,6 +55,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											Name:      "redis-data",
 											MountPath: "/data",
 										},
+										{
+											Name:      "instance-manager",
+											MountPath: "/controller",
+										},
 									},
 								},
 							},
@@ -89,6 +93,12 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											},
 											DefaultMode: &executeMode,
 										},
+									},
+								},
+								{
+									Name: "instance-manager",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
@@ -129,6 +139,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											Name:      "redis-data",
 											MountPath: "/data",
 										},
+										{
+											Name:      "instance-manager",
+											MountPath: "/controller",
+										},
 									},
 								},
 							},
@@ -163,6 +177,12 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											},
 											DefaultMode: &executeMode,
 										},
+									},
+								},
+								{
+									Name: "instance-manager",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 								{
@@ -209,6 +229,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											Name:      "pvc-data",
 											MountPath: "/data",
 										},
+										{
+											Name:      "instance-manager",
+											MountPath: "/controller",
+										},
 									},
 								},
 							},
@@ -243,6 +267,12 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											},
 											DefaultMode: &executeMode,
 										},
+									},
+								},
+								{
+									Name: "instance-manager",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 							},
@@ -319,6 +349,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											Name:      "pvc-data",
 											MountPath: "/data",
 										},
+										{
+											Name:      "instance-manager",
+											MountPath: "/controller",
+										},
 									},
 								},
 							},
@@ -353,6 +387,12 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											},
 											DefaultMode: &executeMode,
 										},
+									},
+								},
+								{
+									Name: "instance-manager",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 							},
@@ -434,6 +474,10 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											Name:      "pvc-data",
 											MountPath: "/data",
 										},
+										{
+											Name:      "instance-manager",
+											MountPath: "/controller",
+										},
 									},
 								},
 							},
@@ -468,6 +512,12 @@ func TestRedisStatefulSetStorageGeneration(t *testing.T) {
 											},
 											DefaultMode: &executeMode,
 										},
+									},
+								},
+								{
+									Name: "instance-manager",
+									VolumeSource: corev1.VolumeSource{
+										EmptyDir: &corev1.EmptyDirVolumeSource{},
 									},
 								},
 							},
@@ -554,7 +604,9 @@ func TestRedisStatefulSetCommands(t *testing.T) {
 			name:          "Default values",
 			givenCommands: []string{},
 			expectedCommands: []string{
-				"redis-server",
+				"/controller/redis-instance",
+				"run",
+				"--redis-conf",
 				"/redis/redis.conf",
 			},
 		},
@@ -2029,8 +2081,20 @@ func TestRedisExtraVolumeMounts(t *testing.T) {
 		ms.On("CreateOrUpdatePodDisruptionBudget", namespace, mock.Anything).Once().Return(nil, nil)
 		ms.On("CreateOrUpdateStatefulSet", namespace, mock.Anything).Once().Run(func(args mock.Arguments) {
 			s := args.Get(1).(*appsv1.StatefulSet)
-			extraVolume = s.Spec.Template.Spec.Volumes[3]
-			extraVolumeMount = s.Spec.Template.Spec.Containers[0].VolumeMounts[4]
+			// Find the extra volume by name (order may vary with instance manager)
+			for _, v := range s.Spec.Template.Spec.Volumes {
+				if v.Name == test.expectedVolumes[0].Name {
+					extraVolume = v
+					break
+				}
+			}
+			// Find the extra volume mount by name
+			for _, vm := range s.Spec.Template.Spec.Containers[0].VolumeMounts {
+				if vm.Name == test.expectedVolumeMounts[0].Name {
+					extraVolumeMount = vm
+					break
+				}
+			}
 		}).Return(nil)
 
 		client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
@@ -2408,12 +2472,9 @@ func TestRedisCustomLivenessProbe(t *testing.T) {
 				FailureThreshold:    6,
 				PeriodSeconds:       15,
 				ProbeHandler: corev1.ProbeHandler{
-					Exec: &corev1.ExecAction{
-						Command: []string{
-							"sh",
-							"-c",
-							"redis-cli -h $(hostname) -p 6379 --user pinger --pass pingpass --no-auth-warning ping | grep PONG",
-						},
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/healthz",
+						Port: intstr.FromInt32(8080),
 					},
 				},
 			},
@@ -2486,38 +2547,35 @@ func TestRedisHTTPLivenessProbeWithInstanceManager(t *testing.T) {
 	assert.True(healthPortFound, "Expected health port 8080 to be added when instance manager is enabled")
 }
 
-func TestRedisExecLivenessProbeWithoutInstanceManager(t *testing.T) {
+func TestRedisDefaultInstanceManagerImage(t *testing.T) {
 	assert := assert.New(t)
 
-	var livenessProbe *corev1.Probe
-	var containerPorts []corev1.ContainerPort
+	var initContainers []corev1.Container
 
 	rf := generateRF()
-	rf.Spec.Redis.InstanceManagerImage = "" // Explicitly no instance manager
+	rf.Spec.Redis.InstanceManagerImage = "" // No explicit image - should use default
 	rf.Spec.Redis.Port = 6379
 
 	ms := &mK8SService.Services{}
 	ms.On("CreateOrUpdatePodDisruptionBudget", namespace, mock.Anything).Once().Return(nil, nil)
 	ms.On("CreateOrUpdateStatefulSet", namespace, mock.Anything).Once().Run(func(args mock.Arguments) {
 		s := args.Get(1).(*appsv1.StatefulSet)
-		livenessProbe = s.Spec.Template.Spec.Containers[0].LivenessProbe
-		containerPorts = s.Spec.Template.Spec.Containers[0].Ports
+		initContainers = s.Spec.Template.Spec.InitContainers
 	}).Return(nil)
 
 	client := rfservice.NewRedisFailoverKubeClient(ms, log.Dummy, metrics.Dummy)
 	err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 	assert.NoError(err)
 
-	// Verify Exec liveness probe is used (legacy behavior)
-	assert.NotNil(livenessProbe)
-	assert.Nil(livenessProbe.HTTPGet, "Expected no HTTPGet probe when instance manager is disabled")
-	assert.NotNil(livenessProbe.Exec, "Expected Exec probe when instance manager is disabled")
-	assert.Contains(livenessProbe.Exec.Command[2], "redis-cli")
-
-	// Verify health port is NOT added to container
-	for _, port := range containerPorts {
-		assert.NotEqual("health", port.Name, "Health port should not be added when instance manager is disabled")
+	// Verify instance manager init container uses default image
+	var instanceManagerFound bool
+	for _, c := range initContainers {
+		if c.Name == "instance-manager-init" {
+			instanceManagerFound = true
+			assert.Equal("ghcr.io/buildio/redis-operator:v4.0.0", c.Image)
+		}
 	}
+	assert.True(instanceManagerFound, "Expected instance-manager-init container with default image")
 }
 
 func TestSentinelCustomLivenessProbe(t *testing.T) {
@@ -2636,9 +2694,12 @@ func TestRedisCustomReadinessProbe(t *testing.T) {
 			expectedReadinessProbe: &corev1.Probe{
 				InitialDelaySeconds: 30,
 				TimeoutSeconds:      5,
+				PeriodSeconds:       10,
+				FailureThreshold:    3,
 				ProbeHandler: corev1.ProbeHandler{
-					Exec: &corev1.ExecAction{
-						Command: []string{"/bin/sh", "/redis-readiness/ready.sh"},
+					HTTPGet: &corev1.HTTPGetAction{
+						Path: "/readyz",
+						Port: intstr.FromInt32(8080),
 					},
 				},
 			},
@@ -2903,13 +2964,13 @@ func TestRedisHTTPReadinessProbeWithInstanceManager(t *testing.T) {
 	assert.Equal(int32(10), readinessProbe.PeriodSeconds)
 }
 
-func TestRedisExecReadinessProbeWithoutInstanceManager(t *testing.T) {
+func TestRedisHTTPReadinessProbeAlwaysUsed(t *testing.T) {
 	assert := assert.New(t)
 
 	var readinessProbe *corev1.Probe
 
 	rf := generateRF()
-	rf.Spec.Redis.InstanceManagerImage = "" // Explicitly no instance manager
+	rf.Spec.Redis.InstanceManagerImage = "" // No explicit image - uses default, HTTP probes required
 	rf.Spec.Redis.Port = 6379
 
 	ms := &mK8SService.Services{}
@@ -2923,9 +2984,9 @@ func TestRedisExecReadinessProbeWithoutInstanceManager(t *testing.T) {
 	err := client.EnsureRedisStatefulset(rf, nil, []metav1.OwnerReference{})
 	assert.NoError(err)
 
-	// Verify Exec readiness probe is used (legacy behavior)
+	// Verify HTTP readiness probe is always used (v4.0.0+)
 	assert.NotNil(readinessProbe)
-	assert.Nil(readinessProbe.HTTPGet, "Expected no HTTPGet probe when instance manager is disabled")
-	assert.NotNil(readinessProbe.Exec, "Expected Exec probe when instance manager is disabled")
-	assert.Contains(readinessProbe.Exec.Command[0], "/bin/sh")
+	assert.NotNil(readinessProbe.HTTPGet, "Expected HTTPGet probe in v4.0.0+")
+	assert.Equal("/readyz", readinessProbe.HTTPGet.Path)
+	assert.Equal(int32(8080), readinessProbe.HTTPGet.Port.IntVal)
 }

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -2510,7 +2510,7 @@ func TestRedisHTTPLivenessProbeWithInstanceManager(t *testing.T) {
 	var containerPorts []corev1.ContainerPort
 
 	rf := generateRF()
-	rf.Spec.Redis.InstanceManagerImage = "ghcr.io/buildio/redis-operator:v1.7.0"
+	rf.Spec.Redis.InstanceManagerImage = "ghcr.io/buildio/redis-operator:1.7.0"
 	rf.Spec.Redis.Port = 6379
 
 	ms := &mK8SService.Services{}
@@ -2568,12 +2568,12 @@ func TestRedisDefaultInstanceManagerImage(t *testing.T) {
 	assert.NoError(err)
 
 	// Verify instance manager init container uses default image
-	// Note: Historical releases use tags without leading 'v' (1.7.0)
+	// Note: Starting with 4.0.0, tags do not have leading 'v'
 	var instanceManagerFound bool
 	for _, c := range initContainers {
 		if c.Name == "instance-manager-init" {
 			instanceManagerFound = true
-			assert.Equal("ghcr.io/buildio/redis-operator:1.7.0", c.Image)
+			assert.Equal("ghcr.io/buildio/redis-operator:4.0.0", c.Image)
 		}
 	}
 	assert.True(instanceManagerFound, "Expected instance-manager-init container with default image")
@@ -2939,7 +2939,7 @@ func TestRedisHTTPReadinessProbeWithInstanceManager(t *testing.T) {
 	var readinessProbe *corev1.Probe
 
 	rf := generateRF()
-	rf.Spec.Redis.InstanceManagerImage = "ghcr.io/buildio/redis-operator:v1.7.0"
+	rf.Spec.Redis.InstanceManagerImage = "ghcr.io/buildio/redis-operator:1.7.0"
 	rf.Spec.Redis.Port = 6379
 
 	ms := &mK8SService.Services{}

--- a/test/integration/redisfailover/creation_test.go
+++ b/test/integration/redisfailover/creation_test.go
@@ -171,7 +171,8 @@ func (c *clients) testCRCreation(t *testing.T) {
 			Redis: redisfailoverv1.RedisSettings{
 				Replicas: redisSize,
 				// Instance manager image must be set to a valid image that exists in the test environment
-				InstanceManagerImage: "ghcr.io/buildio/redis-operator:v1.7.0",
+				// Note: Historical releases (pre-v4.0.0) use tags without leading 'v'
+				InstanceManagerImage: "ghcr.io/buildio/redis-operator:1.7.0",
 				Exporter: redisfailoverv1.Exporter{
 					Enabled: true,
 				},

--- a/test/integration/redisfailover/creation_test.go
+++ b/test/integration/redisfailover/creation_test.go
@@ -170,6 +170,8 @@ func (c *clients) testCRCreation(t *testing.T) {
 		Spec: redisfailoverv1.RedisFailoverSpec{
 			Redis: redisfailoverv1.RedisSettings{
 				Replicas: redisSize,
+				// Instance manager image must be set to a valid image that exists in the test environment
+				InstanceManagerImage: "ghcr.io/buildio/redis-operator:v1.7.0",
 				Exporter: redisfailoverv1.Exporter{
 					Enabled: true,
 				},


### PR DESCRIPTION
## Summary

- Make instance manager the default and only mode (v4.0.0)
- Remove legacy exec probes - only HTTP probes via instance manager
- Align chart version (4.0.0) with operator version
- Default instanceManagerImage to ghcr.io/buildio/redis-operator:v4.0.0

## Breaking Changes

- Instance manager is now always enabled (no opt-out)
- HTTP health probes (`/healthz`, `/readyz`) are the only probe type
- Legacy exec probes are removed

## Migration

- Existing CRDs that specify `instanceManagerImage` continue to work
- Existing CRDs without `instanceManagerImage` will use the default
- No action required for most users

## Test plan

- [x] Unit tests pass
- [ ] E2E tests pass (CI)
- [ ] Verify HTTP probes work correctly
- [ ] Verify instance manager init container uses default image when not specified